### PR TITLE
Show stack traceback of test that is generating an error

### DIFF
--- a/telescope.lua
+++ b/telescope.lua
@@ -382,7 +382,7 @@ function run(contexts, callbacks, test_filter)
       assertions_invoked = assertions_invoked + 1
     end
     setfenv(func, env)
-    local result, message = pcall(func)
+    local result, message = xpcall(func, debug.traceback)
     if result and assertions_invoked > 0 then
       return status_codes.pass, assertions_invoked, nil
     elseif result then


### PR DESCRIPTION
Hello, I'm a newbie at git but I figured I would try to submit this pull request - as far as I can tell the debug.traceback  at line 387:

```
  return status_codes.err, assertions_invoked, {message, debug.traceback()}
```

doesn't provide any useful information about the failing test...it will only generate a stack like this:

stack traceback:
        C:\Program Files\Lua\5.1\lua/telescope.lua:394: in function 'invoke_test'
        C:\Program Files\Lua\5.1\lua/telescope.lua:419: in function 'run'
        ...rogram Files\Lua\5.1\rocks/telescope/0.4.1-1/bin/tsc:266: in main chunk
        [C]: ?

which doesn't tell you anything about the failing test...so instead the submitted change is to capture some useful context from within the failing test itself.

Thanks!
