### PR TITLE
fix infinite loop in assertions when given too many arguments

### DIFF
--- a/telescope.lua
+++ b/telescope.lua
@@ -158,10 +158,13 @@ function make_assertion(name, message, func)
     format_message = function(message, ...)
       local a = {}
       local args = {...}
-      for i = 1, #args do
-        table.insert(a, tostring(args[i]))
+      if #args > num_vars then
+        error(string.format('assert_%s expected %d arguments but got %d', name, num_vars, #args))
       end
-      while num_vars > 0 and #a ~= num_vars do table.insert(a, 'nil') end
+      for _,v in ipairs(args) do
+        table.insert(a, tostring(v))
+      end
+      while num_vars > 0 and #a < num_vars do table.insert(a, 'nil') end
       return (assertion_message_prefix .. message):format(unpack(a))
     end
   end

--- a/telescope.lua
+++ b/telescope.lua
@@ -161,7 +161,7 @@ function make_assertion(name, message, func)
       if #args > num_vars then
         error(string.format('assert_%s expected %d arguments but got %d', name, num_vars, #args))
       end
-      for _,v in ipairs(args) do
+      for _, v in ipairs(args) do
         table.insert(a, tostring(v))
       end
       while #a < num_vars do table.insert(a, 'nil') end

--- a/telescope.lua
+++ b/telescope.lua
@@ -164,7 +164,7 @@ function make_assertion(name, message, func)
       for _,v in ipairs(args) do
         table.insert(a, tostring(v))
       end
-      while num_vars > 0 and #a < num_vars do table.insert(a, 'nil') end
+      while #a < num_vars do table.insert(a, 'nil') end
       return (assertion_message_prefix .. message):format(unpack(a))
     end
   end


### PR DESCRIPTION
Assertions created by make_assertion go on an infinite loop when passed more arguments than expected, e.g. assert_equal('foo','bar','an extra argument'). The problem was with the condition check in the loop that pads the argument table with 'nil' when there are too few arguments.
