### PR TITLE
Sandboxing individual tests

### DIFF
--- a/telescope.lua
+++ b/telescope.lua
@@ -319,6 +319,14 @@ local function load_contexts(target, contexts)
   return context_table
 end
 
+-- in-place table reverse.
+function table.reverse(t)
+     local len = #t+1
+     for i=1, (len-1)/2 do
+          t[i], t[len-i] = t[len-i], t[i]
+     end
+end
+
 --- Run all tests.
 -- This function will exectute each function in the contexts table.
 -- @param contexts The contexts created by <tt>load_contexts</tt>.
@@ -452,6 +460,7 @@ local function run(contexts, callbacks, test_filter)
     result.status_label = status_labels[result.status_code]
 
     -- Run all the "after" blocks/functions
+    table.reverse(ancestors)
     for _, a in ipairs(ancestors) do
       if contexts[a].after then 
         setfenv(contexts[a].after, env)

--- a/telescope.lua
+++ b/telescope.lua
@@ -156,7 +156,13 @@ local function make_assertion(name, message, func)
       local args = {...}
       -- @TODO look into using select("#", ...)
       if #args > num_vars then
-        error(string.format('assert_%s expected %d arguments but got %d', name, num_vars, #args))
+        
+        local userErrorMessage = args[num_vars+1]
+        if type(userErrorMessage) == "string" then
+          return(assertion_message_prefix .. userErrorMessage)
+        else
+          error(string.format('assert_%s expected %d arguments but got %d', name, num_vars, #args))
+        end
       end
       for _, v in ipairs(args) do
         table.insert(a, tostring(v))


### PR DESCRIPTION
Hi there...

I believe my last pull request actually introduced a bug (Which I will remedy here!).  The last pull request placed load_context into its own sandbox.  It appears that any of the functions/blocks that it loaded also inherited these new environments by default.

This appears to be okay, until we hit the run() function and all the test blocks gets their environment changed to the global environment.  The after and before blocks will still run with the sandbox that was given to them during load_context().  So even though the before and after blocks are being run, they are altering an environment that's effectively invisible to the test blocks.

The pull request contains the following changes:
- Proper sandboxing
  
  During run(), we setup a new environment to be shared between all before/after/test blocks on a per-test basis.  That means each test will start with a clean-slate.  No test can accidentally leave behind a global variable that may change the result of the test in unforeseen ways.
- Proper teardown order
  
  The setup code (before blocks) has always been run in the correct order, proceeding from the outer-most into the inner-most blocks.  However, it also runs the tear-down code in the same order, meaning the teardown code for the outer-most blocks is run first before the inner blocks have an opportunity to run.
  
  This _may_ cause problems if the nested blocks actually created nested data structures.  When the teardown code is run for the outer-most contexts, it will likely remove any outer-most data structures also, making any inner context teardown code somewhat pointless.  It's probably only problematic if there are any system level resources that should be shutdown explicitly.
