### PR TITLE
rockspec format fix ?

### DIFF
--- a/rockspecs/telescope-scm-1.rockspec
+++ b/rockspecs/telescope-scm-1.rockspec
@@ -16,12 +16,12 @@ dependencies = {
 }
 
 build = {
-  type = "none",
+  type = "builtin",
+  modules = {
+    ["telescope"] = "telescope.lua",
+    ["telescope.compat_env"] = "telescope/compat_env.lua"
+  },
   install = {
-    lua = {
-      "telescope.lua",
-      ["telescope.compat_env"] = "telescope/compat_env.lua",
-    },
     bin = {
       "tsc"
     }


### PR DESCRIPTION
Hello,

I played to make all-in-one file for telescope (a `tsc` embeding all dependencies).
I never found the `built.type = "none"`.
I'm often found the format like I changed.

Let me know your opinion.
Best Regards,
